### PR TITLE
Downgrading xunit.runner.visualstudio (it has been upgraded by dependabot, but it's not compatible with .NET version)

### DIFF
--- a/src/Likvido.ApiAuth.Tests/Likvido.ApiAuth.Tests.csproj
+++ b/src/Likvido.ApiAuth.Tests/Likvido.ApiAuth.Tests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="NunitXml.TestLogger" Version="3.1.15" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     
-    <PackageReference Include="xunit" Version="2.6.4" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Likvido.ApiAuth.Tests/Likvido.ApiAuth.Tests.csproj
+++ b/src/Likvido.ApiAuth.Tests/Likvido.ApiAuth.Tests.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Shouldly" Version="4.2.1" />
     
     <PackageReference Include="xunit" Version="2.6.4" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
xunit.runner.visualstudio needs to be 2.4.5 to work with the .NET version of this project.